### PR TITLE
Use newMemoryDirectDB instead of newDirectMemoryDB

### DIFF
--- a/kafka-clj/src/kafka_clj/msg_persist.clj
+++ b/kafka-clj/src/kafka_clj/msg_persist.clj
@@ -96,9 +96,9 @@
                                                                       send-cache-expire-after-write 5 
                                                                       send-cache-expire-after-access 5}}]
   "Returns {:db db :cache cache}
-   db is the DBMaker newDirectMemoryDB result
+   db is the DBMaker newMemoryDirectDB result
    and cach is a HTreeMap cache"
-   (let [^DB db (-> (DBMaker/newDirectMemoryDB)
+   (let [^DB db (-> (DBMaker/newMemoryDirectDB)
                  (.sizeLimit (int send-cache-size-limit))     ;limit store size to 2GB
                  (.transactionDisable)    ;better performance
                  (.make))


### PR DESCRIPTION
Hi,

I cannot create a producer now. The exception says:

```
Exception in thread "main" java.lang.ExceptionInInitializerError
        at clojure.main.<clinit>(main.java:20)
Caused by: java.lang.NoSuchFieldException: newDirectMemoryDB, compiling:(kafka_clj/msg_persist.clj:102:21)
```

Traced this back to this rename
https://github.com/jankotek/MapDB/commit/3d7a6fbfa18922385918976c9de1a73ce180f6bc
