### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See https://github.com/gerritjvv/kafka-fast/blob/master/kafka-clj/doc/vagrant.md
 *  0.10.0.0
 *  0.10.1.0
 
-#Usage
+# Usage
 
 ## Leiningen
 
@@ -280,7 +280,7 @@ For testing this is one of the best things you can do and makes testing kafka + 
 
 See: https://github.com/gerritjvv/kafka-fast/blob/master/kafka-clj/doc/vagrant.md
 
-##Monitoring
+## Monitoring
 
 A kafka consumer can have a considerable memory footprint due to buffering and background fetching going on (all done for the sake of performance).  
 To see where and how memory is used several functions are provided in the consumer namespace.   
@@ -341,7 +341,7 @@ To monitor how many active and idle connections are alive in the system use:
 
 ```
 
-###Consumer Work Units and monitoring
+### Consumer Work Units and monitoring
 
 Each consumer will process work units as they become available on the work queue. 
 When a work unit has been completed by the consumer an event is sent to the work-unit-event-ch channel (core.async channel).

--- a/kafka-clj/README.md
+++ b/kafka-clj/README.md
@@ -99,7 +99,7 @@ Consumer
 (<!! msg-ch)
 ```
 
-#Integration Testing
+# Integration Testing
 
 
 The namespace in test ```kafka-clj.util``` contain helper functions to launch  
@@ -113,7 +113,7 @@ Note that Redis must be installed locally.
 All integration tests must be labeled with ```:it```  
 see http://www.jayway.com/2014/09/09/integration-testing-setup-with-midje-and-leiningen/
 
-###To run all integration tests type:  
+### To run all integration tests type:  
 
 ```lein midje :filters it```
 
@@ -121,7 +121,7 @@ see http://www.jayway.com/2014/09/09/integration-testing-setup-with-midje-and-le
 
 ```lein midje :filters -it```
 
-###To run a specific namespace type:
+### To run a specific namespace type:
 
 ```lein midje <namespace>```
 

--- a/kafka-clj/doc/redis-cluster.md
+++ b/kafka-clj/doc/redis-cluster.md
@@ -1,9 +1,9 @@
-#Redis Cluster
+# Redis Cluster
 
 Home: https://github.com/gerritjvv/kafka-fast
 
 
-#Overview
+# Overview
 
 Since: `3.0.0-SNAPSHOT`
 
@@ -71,7 +71,7 @@ The `redis-cluster-init` script reads ports from the `/etc/redis-nodes` file and
 
 
 
-#The Code
+# The Code
 
 The redis namespaces have been divided into:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
